### PR TITLE
Explicitly cast to bool for GCC-6 compatibility

### DIFF
--- a/src/data/serialization/base.h
+++ b/src/data/serialization/base.h
@@ -92,7 +92,7 @@ public:
   }
 
   bool bool_test() const {
-    return is;
+    return static_cast<bool>(is);
   }
 
 private:
@@ -166,7 +166,7 @@ public:
   }
 
   bool bool_test() const {
-    return os;
+    return static_cast<bool>(os);
   }
 
 private:

--- a/src/network/http/base.cpp
+++ b/src/network/http/base.cpp
@@ -132,7 +132,7 @@ header::header(const pfi::lang::shared_ptr<stream_socket>& sock)
 
 static bool istream_getline(istream* is, string* str)
 {
-  return getline(*is, *str);
+  return static_cast<bool>(getline(*is, *str));
 }
 
 header::header(istream& is)


### PR DESCRIPTION
Building with GCC-6.3.0 fails with errors such as:

```
../src/network/http/base.cpp:135:27: error: cannot convert 'std::basic_istream<char>' to 'bool' in return
   return getline(*is, *str);
                           ^
```

Implicit conversion to `bool` for `std::istream` or `std::ostream` is no longer allowed.  Instead, there exist `explicit operator bool() const;` explicit conversion methods for such types in C++11.  Explicit casting to `bool` should always work, regardless.