### PR TITLE
use istream::good and ostream::good method explicitly

### DIFF
--- a/src/data/serialization/base.h
+++ b/src/data/serialization/base.h
@@ -92,7 +92,7 @@ public:
   }
 
   bool bool_test() const {
-    return is;
+    return is.good();
   }
 
 private:
@@ -166,7 +166,7 @@ public:
   }
 
   bool bool_test() const {
-    return os;
+    return os.good();
   }
 
 private:

--- a/src/network/http/base.cpp
+++ b/src/network/http/base.cpp
@@ -132,7 +132,8 @@ header::header(const pfi::lang::shared_ptr<stream_socket>& sock)
 
 static bool istream_getline(istream* is, string* str)
 {
-  return getline(*is, *str);
+  getline(*is, *str);
+  return is->good();
 }
 
 header::header(istream& is)


### PR DESCRIPTION
When I compiled pficommon with the option  `-std=c++11`, I failed to compile.

This failure occurs since C++11 doesn't allow some kind of implicit conversions, but pficommon depends on such a technique. This pull request use `istream::good()` or `ostream::good()` to avoid this issue.