### PR TITLE
not to install convenience libraries

### DIFF
--- a/src/database/mysql/wscript
+++ b/src/database/mysql/wscript
@@ -3,11 +3,10 @@ def build(bld):
       'connection.h'
       ])
 
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'connection.cpp statement.cpp value.cpp',
     target = 'pficommon_database_mysql',
-    install_path = '${PREFIX}/lib',
     includes = '. ..',
     vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent MYSQL')

--- a/src/database/postgresql/wscript
+++ b/src/database/postgresql/wscript
@@ -3,11 +3,10 @@ def build(bld):
       'connection.h',
       ])
   
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'connection.cpp statement.cpp result.cpp value.cpp',
     target = 'pficommon_database_postgresql',
-    install_path = '${PREFIX}/lib',
     includes = '. ..',
     vnum = bld.env['VERSION'],
     use = 'PGSQL')

--- a/src/database/wscript
+++ b/src/database/wscript
@@ -48,7 +48,7 @@ def build(bld):
     features = bld.env.FEATURES,
     source = '',
     target = 'pficommon_database',
-    install_path = None,
+    install_path = '${PREFIX}/lib',
     use = [])
   
   if bld.env.BUILD_MYSQL:

--- a/src/network/cgi/wscript
+++ b/src/network/cgi/wscript
@@ -43,11 +43,10 @@ def build(bld):
       'server.h',
       ])
 
-  cgi = bld(
-    features = bld.env.FEATURES,
+  cgi = bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'base.cpp xhtml_cgi.cpp xhtml_builder.cpp inserter.cpp cgi.cpp server.cpp util.cpp',
     target = 'pficommon_network_cgi',
-    install_path = '${PREFIX}/lib',
     includes = '. ..',
     vnum = bld.env['VERSION'],
     use = 'pficommon_text pficommon_concurrent pficommon_network_http PTHREAD')

--- a/src/network/http/wscript
+++ b/src/network/http/wscript
@@ -10,11 +10,10 @@ def build(bld):
       'stream.h',
       ])
 
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'base.cpp',
     target = 'pficommon_network_http',
-    install_path = '${PREFIX}/lib',
     includes = '. ..',
     vnum = bld.env['VERSION'],
     use = 'pficommon_network_base')

--- a/src/network/mprpc/wscript
+++ b/src/network/mprpc/wscript
@@ -12,8 +12,8 @@ def build(bld):
       'socket.h',
       ])
 
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = [
       'object_stream.cpp',
       'rpc_client.cpp',
@@ -22,6 +22,5 @@ def build(bld):
       'socket.cpp'
       ],
     target = 'pficommon_network_mprpc',
-    install_path = '${PREFIX}/lib',
     vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent pficommon_network_base MSGPACK')

--- a/src/network/rpc/wscript
+++ b/src/network/rpc/wscript
@@ -13,11 +13,10 @@ def build(bld):
       'reflect.h',
       ])
 
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'base.cpp',
     target = 'pficommon_network_rpc',
-    install_path = '${PREFIX}/lib',
     includes = '. ..',
     vnum = bld.env['VERSION'],
     use = 'pficommon_network_base pficommon_concurrent pficommon_system')

--- a/src/network/wscript
+++ b/src/network/wscript
@@ -52,11 +52,10 @@ def build(bld):
       'rpc.h',
       ])
 
-  bld(
-    features = bld.env.FEATURES,
+  bld.objects(
+    cxxflags = bld.env.OBJECTS_CXXFLAGS,
     source = 'socket.cpp ipv4.cpp dns.cpp uri.cpp',
     target = 'pficommon_network_base',
-    install_path = '${PREFIX}/lib',
     includes = '.',
     vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent')
@@ -65,7 +64,7 @@ def build(bld):
     features = bld.env.FEATURES,
     source = '',
     target = 'pficommon_network',
-    install_path = None,
+    install_path = '${PREFIX}/lib',
     use = [
       'pficommon_network_base',
       'pficommon_network_http',

--- a/wscript
+++ b/wscript
@@ -45,6 +45,7 @@ def configure(conf):
   conf.env['VERSION'] = VERSION
 
   conf.env['FEATURES'] = 'cxx cxxstlib' if Options.options.static else 'cxx cxxshlib'
+  conf.env['OBJECTS_CXXFLAGS'] = conf.env.CXXFLAGS_cxxstlib if Options.options.static else conf.env.CXXFLAGS_cxxshlib
   
   conf.write_config_header('src/pfi-config.h')
   
@@ -97,7 +98,7 @@ def build(bld):
       if not isinstance(task.generator, waflib.TaskGen.task_gen):
         continue
       g = task.generator
-      if any(f in g.features for f in ['cxxshlib', 'cxxstlib']) and g.install_path is not None:
+      if any(f in g.features for f in ['cxxshlib', 'cxxstlib']) and getattr(g, 'install_path', None) is not None:
         libs.append(g.target)
   ls = ''
   for l in set(libs):


### PR DESCRIPTION
install `libpficommon_database.{a,so}` `libpficommon_network.{a,so}` instead of `libpficommon_database_*.{a,so}` `libpficommon_network_*.{a,so}`

```
Binary files before_st/lib/libpficommon.a and after_st/lib/libpficommon.a differ
Only in after_st/lib: libpficommon_database.a
Only in before_st/lib: libpficommon_database_mysql.a
Only in before_st/lib: libpficommon_database_postgresql.a
Only in after_st/lib: libpficommon_network.a
Only in before_st/lib: libpficommon_network_base.a
Only in before_st/lib: libpficommon_network_cgi.a
Only in before_st/lib: libpficommon_network_http.a
Only in before_st/lib: libpficommon_network_mprpc.a
Only in before_st/lib: libpficommon_network_rpc.a
diff -r before_st/lib/pkgconfig/pficommon.pc after_st/lib/pkgconfig/pficommon.pc
1c1
< prefix=/home/takei/before_st
---
> prefix=/home/takei/after_st
3c3
< libdir=/home/takei/before_st/lib
---
> libdir=/home/takei/after_st/lib
10c10
< Libs: -L${libdir}  -lpficommon -lpficommon_visualization -lpficommon_text -lpficommon_network_mprpc -lpficommon_network_base -lpficommon_concurrent -lpficommon_data -lpficommon_math -lpficommon_system -lpficommon_database_postgresql -lpficommon_network_http -lpficommon_database_mysql -lpficommon_lang -lpficommon_network_rpc -lpficommon_network_cgi -lmsgpack -lpthread
---
> Libs: -L${libdir}  -lpficommon -lpficommon_visualization -lpficommon_text -lpficommon_network -lpficommon_concurrent -lpficommon_data -lpficommon_database -lpficommon_math -lpficommon_system -lpficommon_lang -lmsgpack -lpthread
```