### PR TITLE
Remove sleep in time_util_test

### DIFF
--- a/src/system/time_util_test.cpp
+++ b/src/system/time_util_test.cpp
@@ -87,9 +87,8 @@ TEST_P(time_util, causality){
 
 TEST_P(time_util, metric){
   double begin=get_clock_time();
-  sleep(1);
   double end=get_clock_time();
-  EXPECT_TRUE(end-begin>=1-1e-2);
+  EXPECT_TRUE(end-begin<=1e-2);
 }
 
 TEST_P(time_util, calendar){

--- a/src/system/time_util_test.cpp
+++ b/src/system/time_util_test.cpp
@@ -88,7 +88,7 @@ TEST_P(time_util, causality){
 TEST_P(time_util, metric){
   double begin=get_clock_time();
   double end=get_clock_time();
-  EXPECT_TRUE(end-begin<=1e-2);
+  EXPECT_LE(begin, end);
 }
 
 TEST_P(time_util, calendar){


### PR DESCRIPTION
Overhead of calling `sleep` may cause a failure of the test.
In this context, we can test the behaviour of `get_clock_time` without `sleep`.