### PR TITLE
Rpc server  get port num

### DIFF
--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -53,6 +53,7 @@ static const char *PONG_MSG = "<<<PONG>>>";
 rpc_server::rpc_server(int version)
   :version(version)
 {
+  port_num = 0;
 }
 
 rpc_server::~rpc_server()
@@ -70,6 +71,8 @@ bool rpc_server::serv(uint16_t port, int nthreads)
   if (!ssock->create(port))
     return false;
 
+  port_num = ssock->port();
+
   vector<pfi::lang::shared_ptr<thread> > ths(nthreads);
   for (int i=0; i<nthreads; i++){
       ths[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&rpc_server::process, this, ssock)));
@@ -78,6 +81,11 @@ bool rpc_server::serv(uint16_t port, int nthreads)
   for (int i=0; i<nthreads; i++)
     ths[i]->join();
   return true;
+}
+
+uint16_t rpc_server::port() const
+{
+  return port_num;
 }
 
 void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -66,6 +66,8 @@ public:
 
   bool serv(uint16_t port, int nthreads);
 
+  uint16_t port() const;
+
 private:
   void add(const std::string &name,
            const pfi::lang::shared_ptr<invoker_base>& invoker);
@@ -73,6 +75,8 @@ private:
   void process(const pfi::lang::shared_ptr<server_socket>& sock);
 
   std::map<std::string, pfi::lang::shared_ptr<invoker_base> > funcs;
+
+  uint16_t port_num;
 
   const int version;
 };

--- a/src/network/rpc_test.cpp
+++ b/src/network/rpc_test.cpp
@@ -199,7 +199,7 @@ TEST(rpc, test_server_port_0)
   sleep(1);
 
   uint16_t p0 = sas.sv.port();
-  EXPECT_NE(0,p0);
+  EXPECT_NE(0, p0);
 
   testrpc_client cln("localhost", p0);
   {

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -483,14 +483,18 @@ bool server_socket::create(uint16_t port_num, int backlog)
     return false;
   }
 
-  socklen_t len = sizeof(saddr);
-  NO_INTR(res, ::getsockname(sock, (sockaddr*)&saddr, &len));
-  if (FAILED(res)){
-    NO_INTR(res, ::close(sock));
-    return false;
+  if (port_num != 0) {
+    this->port_num=port_num;
   }
-
-  this->port_num=ntohs(saddr.sin_port);
+  else {
+    socklen_t len = sizeof(saddr);
+    NO_INTR(res, ::getsockname(sock, (sockaddr*)&saddr, &len));
+    if (FAILED(res)){
+      NO_INTR(res, ::close(sock));
+      return false;
+    }
+    this->port_num=ntohs(saddr.sin_port);
+  }
   connected=true;
   return true;
 }

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -483,7 +483,14 @@ bool server_socket::create(uint16_t port_num, int backlog)
     return false;
   }
 
-  this->port_num=port_num;
+  socklen_t len = sizeof(saddr);
+  NO_INTR(res, ::getsockname(sock, (sockaddr*)&saddr, &len));
+  if (FAILED(res)){
+    NO_INTR(res, ::close(sock));
+    return false;
+  }
+
+  this->port_num=ntohs(saddr.sin_port);
   connected=true;
   return true;
 }


### PR DESCRIPTION
## 対応Issue / 関連Issue

<!-- fixes #N / close #N / refs #N -->

## 設計方針 / 実装方法

<!--
* なにをどう変更したか
* なぜその設計にしたのか
* などなど、
* レビュワーにわかるように、技術的視線での変更概要説明
-->
* 対象： rpc_server 
	* 現時点で空いているポート番号の中から 待ち受けポートを確保し サーバ稼働して欲しい。
		* socket 関数で server を用意する場合に 、bind() で port番号に 0 を指定して listen() する運用 と同様な事がしたい。
		* rpc::server も 起動引数の port 番号に 0 を指定すると、↑の挙動をするが、port 番号の何番を確保したのかを知る手段が用意されてなかった。
		* そこで今回 rpc_server の 起動時に 実際に確保したポート番号を getsockname() で取得し、rpc_server を利用するレイヤに伝達する手段を実装した。 

## 動かし方

<!--
* (もし追加/変更があれば)
* 使い方の説明
* 再現条件 (例えば、いいねの状態、デバイスの状態、プランの状態や、設定によってこういう風に使える、とかこういう画面が出てくる、とか条件があれば)
-->

## UIに対する変更

<!--
* 変更前のスクリーンショット
* 変更後のスクリーンショット
-->

## テスト結果とテスト項目

* [x] ./waf --checkall が通ること。

<!--
- バグ修正であれば、再現手順

* [ ] テストする際の項目を、このように、チェック可能な形式で記載する。
* [ ] テストしたらチェックを入れていく。
* [ ] 他チームへテストを依頼した場合はチーム名書いておこう
* [ ] それをテストしたチームの人が、チェックを入れよう
* [ ] (レビュワー)テスト項目のチェック
-->

## 今回保留した項目とTODOリスト

<!--
箇条書きで書く。できれば次のチケットを作る。

* あれこれを治す #xxxxxx
* あれそれを実装する #xxxxxx
-->

## 関連URL

<!--
* WikiのURL(Markdown形式)や ...
* 画像URL や ...
* 操作可能な画面のURLや ...
* (あれば...) ...
-->

## その他

<!--
* レビュワーに対する注意点 (ここはこういう風に思ったけどこういう風に実装した、ここはこうしようと思ったんだけどこういう悩みがありやめた、など注意点があれば)
* リリースに対する注意点 (その他)
-->
