### PR TITLE
Fixed src/databse/wscript and src/network/wscript to create versioned libraries

### DIFF
--- a/src/database/wscript
+++ b/src/database/wscript
@@ -49,6 +49,7 @@ def build(bld):
     source = '',
     target = 'pficommon_database',
     install_path = '${PREFIX}/lib',
+    vnum = bld.env['VERSION'],
     use = [])
   
   if bld.env.BUILD_MYSQL:

--- a/src/network/wscript
+++ b/src/network/wscript
@@ -65,6 +65,7 @@ def build(bld):
     source = '',
     target = 'pficommon_network',
     install_path = '${PREFIX}/lib',
+    vnum = bld.env['VERSION'],
     use = [
       'pficommon_network_base',
       'pficommon_network_http',


### PR DESCRIPTION
refs #185 

libpficommon_database.so and libpficommon_network.so are created and installed, but libpficommon_database.so.3.0.0 and libpficommon_network.so.3.0.0 are NOT created and installed.

This pull request resolve this issue.

Following files will be created and installed:

* databse
   * libpficommon_database.so.3
   * libpficommon_database.so.3.0.0
* network
  * libpficommon_network.so.3
  * libpficommon_network.so.3.0.0
