### PR TITLE
Add patches/fcgi.patch and use it in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,7 @@ jobs:
           command: |
             wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz
             tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz && cd fcgi-2.4.1-SNAP-0910052249
-            curl https://gist.githubusercontent.com/himkt/fa07b36c9afec57db067c725e8e5e4d8/raw/d5f424a22eba7a2c139324f0b9638b84fe0afafc/fcgi.patch > patch
-            patch -u libfcgi/fcgio.cpp < patch
+            patch -u libfcgi/fcgio.cpp < ../patches/fcgi.patch
             ./configure && make && make install
       - run:
           name: install mysql
@@ -120,8 +119,7 @@ jobs:
           command: |
             wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz
             tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz && cd fcgi-2.4.1-SNAP-0910052249
-            curl https://gist.githubusercontent.com/himkt/fa07b36c9afec57db067c725e8e5e4d8/raw/d5f424a22eba7a2c139324f0b9638b84fe0afafc/fcgi.patch > patch
-            patch -u libfcgi/fcgio.cpp < patch
+            patch -u libfcgi/fcgio.cpp < ../patches/fcgi.patch
             ./configure && make && make install
       - run:
           name: install mysql

--- a/patches/fcgi.patch
+++ b/patches/fcgi.patch
@@ -1,0 +1,10 @@
+--- libfcgi/fcgio.cpp	2020-05-13 12:36:17.587650250 +0900
++++ libfcgi/fcgio.cpp.bak	2020-05-13 12:36:05.675524618 +0900
+@@ -23,6 +23,7 @@
+ #endif
+ 
+ #include <limits.h>
++#include <stdio.h>
+ #include "fcgio.h"
+ 
+ using std::streambuf;


### PR DESCRIPTION
because CI failed because fcgi.patch on gist was 404.
It's debatable that adding `patches` directory to the root directory of this repository.