### PR TITLE
Fix a bug that build in C++11 mode is not enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: configure using python3.4 and c++11
           command: |
-            CPPFLAGS="-std=c++11 -I/usr/include/postgresql -Wno-deprecated-declarations" python3 ./waf configure --disable-fcgi
+            CXXFLAGS="-std=c++11 -Wno-deprecated-declarations" python3 ./waf configure --disable-fcgi
       - run:
           name: build using python3.4
           command: python3 ./waf build
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: configure
           command: |
-            CPPFLAGS="-std=c++11 -I/usr/include/postgresql -Wno-deprecated-declarations" ./waf configure --disable-fcgi
+            CXXFLAGS="-std=c++11 -Wno-deprecated-declarations" CPPFLAGS="-I/usr/include/postgresql" ./waf configure --disable-fcgi
       - run:
           name: build
           command: ./waf build


### PR DESCRIPTION
# What I've done

Fixed a bug that build in C++11 mode is not enabled because `CPPFLAGS` , which is a flag for C preprocessor, was used.
So I've replaced `CPPFLAGS` with `CXXFLAGS` to enable C++11 build.

In addition, I've deleted `-I/usr/include/postgresql` from `gcc5_c++11_python34` job because we don't need to pass that path in a non-full build.

# How to test

You can check to see if `CXXFLAGS` value contains `-std=c++11 -Wno-deprecated-declarations` after running `./waf configure` in `gcc5_c++11_python34` and `gcc5_c++11_full` job.