### PR TITLE
Replace std::auto_ptr with std::unique_ptr (except pfi::lang::shared_ptr)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,29 +39,6 @@ jobs:
       - run:
           name: install using python3.4
           command: python3 ./waf install
-  gcc5_c++11_python34:
-    docker:
-      - image: gcc:5
-    steps:
-      - checkout
-      - run:
-          name: install python3.4
-          command: |
-            apt update -y
-            apt install -y python3
-      - run:
-          name: configure using python3.4 and c++11
-          command: |
-            CXXFLAGS="-std=c++11 -Wno-deprecated-declarations" python3 ./waf configure --disable-fcgi
-      - run:
-          name: build using python3.4
-          command: python3 ./waf build
-      - run:
-          name: test using python3.4 and c++11
-          command: python3 ./waf --check
-      - run:
-          name: install using python3.4 and c++11
-          command: python3 ./waf install
   gcc5_full:
     docker:
       - image: gcc:5
@@ -103,54 +80,10 @@ jobs:
       - run:
           name: install
           command: ./waf install
-  gcc5_c++11_full:
-    docker:
-      - image: gcc:5
-    steps:
-      - checkout
-      - run:
-          name: install msgpack
-          command: |
-            wget https://github.com/msgpack/msgpack-c/releases/download/cpp-0.5.9/msgpack-0.5.9.tar.gz
-            tar zxvf msgpack-0.5.9.tar.gz && cd msgpack-0.5.9
-            ./configure && make && make install
-      - run:
-          name: install fcgi
-          command: |
-            wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz
-            tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz && cd fcgi-2.4.1-SNAP-0910052249
-            patch -u libfcgi/fcgio.cpp < ../patches/fcgi.patch
-            ./configure && make && make install
-      - run:
-          name: install mysql
-          command: |
-            apt update -y
-            apt install libmysqlclient-dev libmysqlclient18 mysql-common
-      - run:
-          name: install postgresql
-          command: |
-            apt update -y
-            apt install -y postgresql postgresql-server-dev-all
-      - run:
-          name: configure
-          command: |
-            CXXFLAGS="-std=c++11 -Wno-deprecated-declarations" CPPFLAGS="-I/usr/include/postgresql" ./waf configure --disable-fcgi
-      - run:
-          name: build
-          command: ./waf build
-      - run:
-          name: test pficommon with all extensions except to imagemagick
-          command: ./waf --check
-      - run:
-          name: install
-          command: ./waf install
-
 workflows:
   version: 2
   build_and_test:
     jobs:
       - gcc5_python27
       - gcc5_python34
-      - gcc5_c++11_python34
       - gcc5_full
-      - gcc5_c++11_full

--- a/src/concurrent/lock.h
+++ b/src/concurrent/lock.h
@@ -59,9 +59,9 @@ public:
       need_unlock=true;
   }
 
-  explicit scoped_lock(std::auto_ptr<lockable> p)
+  explicit scoped_lock(std::unique_ptr<lockable> p)
     : l(NULL)
-    , lp(p)
+    , lp(std::move(p))
     , need_unlock(false){
     if (lp->lock())
       need_unlock=true;
@@ -82,7 +82,7 @@ public:
 
 private:
   lockable *l;
-  mutable std::auto_ptr<lockable> lp;
+  mutable std::unique_ptr<lockable> lp;
   mutable bool need_unlock;
 };
 

--- a/src/concurrent/rwmutex.h
+++ b/src/concurrent/rwmutex.h
@@ -122,24 +122,24 @@ private:
   double sec;
 };
 
-inline std::auto_ptr<lockable> rlock(rw_mutex &m)
+inline std::unique_ptr<lockable> rlock(rw_mutex &m)
 {
-  return std::auto_ptr<lockable>(new rlocker(m));
+  return std::unique_ptr<lockable>(new rlocker(m));
 }
 
-inline std::auto_ptr<lockable> rlock(rw_mutex &m, double sec)
+inline std::unique_ptr<lockable> rlock(rw_mutex &m, double sec)
 {
-  return std::auto_ptr<lockable>(new rlocker(m,sec));
+  return std::unique_ptr<lockable>(new rlocker(m,sec));
 }
 
-inline std::auto_ptr<lockable> wlock(rw_mutex &m)
+inline std::unique_ptr<lockable> wlock(rw_mutex &m)
 {
-  return std::auto_ptr<lockable>(new wlocker(m));
+  return std::unique_ptr<lockable>(new wlocker(m));
 }
 
-inline std::auto_ptr<lockable> wlock(rw_mutex &m, double sec)
+inline std::unique_ptr<lockable> wlock(rw_mutex &m, double sec)
 {
-  return std::auto_ptr<lockable>(new wlocker(m,sec));
+  return std::unique_ptr<lockable>(new wlocker(m,sec));
 }
 
 // for spped optimization

--- a/src/lang/bind_test.cpp
+++ b/src/lang/bind_test.cpp
@@ -95,76 +95,76 @@ public:
 
 TEST(bind, bind_test)
 {
-  ASSERT_EQ(246, bind(&foo1, _1)(123));
-  ASSERT_EQ(246, bind(&foo1, 123)());
-  ASSERT_EQ(246, bind(&foo1, _1)(123, 456, 789, 123, 456, 789));
-  ASSERT_EQ(579, bind(&foo2, _1, _2)(123, 456));
-  ASSERT_EQ(579, bind(&foo2, 123, _2)(123, 456));
-  ASSERT_EQ(579, bind(&foo2, _1, 456)(123));
-  ASSERT_EQ(246, bind(&foo2, _1, _1)(123));
-  ASSERT_EQ(912, bind(&foo2, _2, _2)(123, 456));
-  ASSERT_EQ("hogehoge", bind(&foo3, _1)("hoge"));
+  ASSERT_EQ(246, pfi::lang::bind(&foo1, _1)(123));
+  ASSERT_EQ(246, pfi::lang::bind(&foo1, 123)());
+  ASSERT_EQ(246, pfi::lang::bind(&foo1, _1)(123, 456, 789, 123, 456, 789));
+  ASSERT_EQ(579, pfi::lang::bind(&foo2, _1, _2)(123, 456));
+  ASSERT_EQ(579, pfi::lang::bind(&foo2, 123, _2)(123, 456));
+  ASSERT_EQ(579, pfi::lang::bind(&foo2, _1, 456)(123));
+  ASSERT_EQ(246, pfi::lang::bind(&foo2, _1, _1)(123));
+  ASSERT_EQ(912, pfi::lang::bind(&foo2, _2, _2)(123, 456));
+  ASSERT_EQ("hogehoge", pfi::lang::bind(&foo3, _1)("hoge"));
   {
     string tmp="hello";
-    bind(&foo4, _1)(tmp);
+    pfi::lang::bind(&foo4, _1)(tmp);
     ASSERT_EQ("hello, world", tmp);
   }
-  ASSERT_EQ(45, bind(&foo5, _1, _2, _3, _4, _5, _6, _7, _8, _9)(1, 2, 3, 4, 5, 6, 7, 8, 9));
+  ASSERT_EQ(45, pfi::lang::bind(&foo5, _1, _2, _3, _4, _5, _6, _7, _8, _9)(1, 2, 3, 4, 5, 6, 7, 8, 9));
   {
     string tmp="hello";
-    bind(&foo6, _1, _2)(tmp, ", world");
+    pfi::lang::bind(&foo6, _1, _2)(tmp, ", world");
     ASSERT_EQ("hello, world", tmp);
   }
 
-  ASSERT_EQ(369, bind(&bar1::foo, bar1(), _1)(123));
+  ASSERT_EQ(369, pfi::lang::bind(&bar1::foo, bar1(), _1)(123));
   {
     bar2 b(100);
-    bind(&bar2::foo, _1, _2)(b, 1);
+    pfi::lang::bind(&bar2::foo, _1, _2)(b, 1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar2 b(100);
-    bind(&bar2::foo, ref(b), _1)(1);
+    pfi::lang::bind(&bar2::foo, pfi::lang::ref(b), _1)(1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar2 b(100);
-    bind(&bar2::foo, _1, _2)(&b, 1);
+    pfi::lang::bind(&bar2::foo, _1, _2)(&b, 1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar2 b(100);
-    bind(&bar2::foo, &b, _1)(1);
+    pfi::lang::bind(&bar2::foo, &b, _1)(1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar21 b(100);
-    bind(&bar2::foo, &b, _1)(1);
+    pfi::lang::bind(&bar2::foo, &b, _1)(1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar21 b(100);
-    bind(&bar2::foo, ref(b), _1)(1);
+    bind(&bar2::foo, pfi::lang::ref(b), _1)(1);
     ASSERT_EQ(101, b.n);
   }
   {
     bar3 b("Hello");
     string w=", world!";
-    ASSERT_EQ("Hello, world!", bind(&bar3::foo, &b, _1)(w));
+    ASSERT_EQ("Hello, world!", pfi::lang::bind(&bar3::foo, &b, _1)(w));
   }
   {
     bar3 b("Hello");
     string w=", world!";
-    ASSERT_EQ("Hello, world!", bind(&bar3::foo, ref(b), _1)(w));
+    ASSERT_EQ("Hello, world!", pfi::lang::bind(&bar3::foo, pfi::lang::ref(b), _1)(w));
   }
   {
     bar3 b("Hello");
     string w=", world!";
-    ASSERT_EQ("Hello, world!", bind(&bar3::foo2, &b, _1)(w));
+    ASSERT_EQ("Hello, world!", pfi::lang::bind(&bar3::foo2, &b, _1)(w));
   }
   {
     bar3 b("Hello");
     string w=", world!";
-    ASSERT_EQ("Hello, world!",  bind(&bar3::foo2, ref(b), _1)(w));
+    ASSERT_EQ("Hello, world!",  pfi::lang::bind(&bar3::foo2, pfi::lang::ref(b), _1)(w));
   }
 }

--- a/src/network/mprpc/message.h
+++ b/src/network/mprpc/message.h
@@ -46,16 +46,16 @@ struct rpc_message {
 public:
   rpc_message() { }
 
-  rpc_message(msgpack::object obj, std::auto_ptr<msgpack::zone> z) :
-    zone(z)
+  rpc_message(msgpack::object obj, std::unique_ptr<msgpack::zone> z) :
+    zone(std::move(z))
   {
     obj.convert(&tuple);
   }
 
-  void reset(msgpack::object obj, std::auto_ptr<msgpack::zone> z)
+  void reset(msgpack::object obj, std::unique_ptr<msgpack::zone> z)
   {
     obj.convert(&tuple);
-    zone = z;
+    zone = std::move(z);
   }
 
   bool is_request()   { return tuple.a0 == 0; }
@@ -66,7 +66,7 @@ public:
   msgpack::type::tuple<uint8_t, uint32_t,
     msgpack::object, msgpack::object> tuple;
 
-  std::auto_ptr<msgpack::zone> zone;
+  std::unique_ptr<msgpack::zone> zone;
 };
 
 
@@ -84,7 +84,7 @@ struct rpc_request {
     msgid  = msg.tuple.a1;
              msg.tuple.a2.convert(&method);
     param  = msg.tuple.a3;
-    zone   = msg.zone;
+    zone   = std::move(msg.zone);
   }
 
   template <typename ObjectWritable, typename P>
@@ -107,7 +107,7 @@ struct rpc_request {
   uint32_t msgid;
   std::string method;
   msgpack::object param;
-  std::auto_ptr<msgpack::zone> zone;
+  std::unique_ptr<msgpack::zone> zone;
 };
 
 
@@ -125,7 +125,7 @@ struct rpc_response {
     msgid  = msg.tuple.a1;
              msg.tuple.a2.convert(&error);
              msg.tuple.a3.convert(&result);
-    zone   = msg.zone;
+    zone   = std::move(msg.zone);
   }
 
   template <typename ObjectWritable, typename R, typename E>
@@ -180,7 +180,7 @@ struct rpc_response {
   uint32_t msgid;
   msgpack::object error;
   msgpack::object result;
-  std::auto_ptr<msgpack::zone> zone;
+  std::unique_ptr<msgpack::zone> zone;
 
 private:
   static std::string object_to_string(msgpack::object o)

--- a/src/network/mprpc/object_stream.cpp
+++ b/src/network/mprpc/object_stream.cpp
@@ -64,7 +64,7 @@ object_stream::~object_stream()
   ::close(iofd);
 }
 
-int object_stream::read(msgpack::object* obj, std::auto_ptr<msgpack::zone>* zone,
+int object_stream::read(msgpack::object* obj, std::unique_ptr<msgpack::zone>* zone,
     double timeout_sec)
 {
   clock_time start = get_clock_time();

--- a/src/network/mprpc/object_stream.h
+++ b/src/network/mprpc/object_stream.h
@@ -47,7 +47,7 @@ public:
   object_stream(const std::string& host, uint16_t port);
   ~object_stream();
 
-  int read(msgpack::object* obj, std::auto_ptr<msgpack::zone>* zone,
+  int read(msgpack::object* obj, std::unique_ptr<msgpack::zone>* zone,
   double timeout_sec);
 
   template <typename T>

--- a/src/network/mprpc/rpc_stream.cpp
+++ b/src/network/mprpc/rpc_stream.cpp
@@ -44,7 +44,7 @@ rpc_stream::~rpc_stream() { }
 int rpc_stream::try_receive(rpc_message* msg)
 {
   msgpack::object obj;
-  std::auto_ptr<msgpack::zone> zone;
+  std::unique_ptr<msgpack::zone> zone;
 
   int ret = os.read(&obj, &zone, timeout_sec);
   if(ret <= 0) {
@@ -52,7 +52,7 @@ int rpc_stream::try_receive(rpc_message* msg)
   }
 
   try {
-    msg->reset(obj, zone);
+    msg->reset(obj, std::move(zone));
   } catch (msgpack::type_error&) {
     return -1;
   }

--- a/src/text/json/base.h
+++ b/src/text/json/base.h
@@ -211,7 +211,7 @@ public:
 
 private:
   json_value* clone() const {
-    std::auto_ptr<json_array> arr(new json_array);
+    std::unique_ptr<json_array> arr(new json_array);
     for (size_t i = 0; i < dat.size(); ++i)
       arr->add(dat[i].clone());
     return arr.release();
@@ -414,7 +414,7 @@ public:
 
   template <class F>
   json_object* merge_with(json_object* obj, F f) const {
-    std::auto_ptr<json_object> ret(new json_object);
+    std::unique_ptr<json_object> ret(new json_object);
     for (const_iterator it = this->begin(); it != this->end(); ++it) {
       ret->add(it->first,it->second);
     }
@@ -495,7 +495,7 @@ public:
 
 private:
   json_value* clone() const {
-    std::auto_ptr<json_object> obj(new json_object);
+    std::unique_ptr<json_object> obj(new json_object);
     for (const_iterator it = member.begin(), end = member.end(); it != end; ++it)
       obj->add(it->first, it->second.clone());
     return obj.release();

--- a/wscript
+++ b/wscript
@@ -31,7 +31,7 @@ def configure(conf):
   conf.load('gnu_dirs')
 
   env = conf.env
-  env.append_unique('CXXFLAGS', ['-O2', '-Wall', '-g', '-pipe', '-D_REENTRANT', '-fno-omit-frame-pointer'])
+  env.append_unique('CXXFLAGS', ['-O2', '-Wall', '-g', '-pipe', '-D_REENTRANT', '-fno-omit-frame-pointer', '-std=c++11', '-Wno-deprecated-declarations'])
   ver = env.CC_VERSION
   if env.COMPILER_CXX != 'g++' or int(ver[0]) < 4 or (int(ver[0]) == 4 and int(ver[1]) < 6):
     env.append_unique('CXXFLAGS', '-D_FORTIFY_SOURCE=1')


### PR DESCRIPTION
# What I've done

Replaced `std::auto_ptr` with `std::unique_ptr` except `pfi::lang::shared_ptr` which internally uses `tr1::shared_ptr` which cannot receive `std::unique_ptr`.
Also, deleted `gcc5_c++11_python34` and `gcc5_c++11_full` job from CI because now `-std=c++11` is enabled by default.