### PR TITLE
Run CI jobs in gcc{5-9}-based Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,82 +1,102 @@
 version: 2
 jobs:
-  gcc5_python27:
+  gcc5:
     docker:
-      - image: gcc:5
+      - image: docker.retrieva.jp/pficommon_ci:gcc5.2007
+        auth:
+          username: $DOCKER_REPO_USER
+          password: $DOCKER_REPO_PASSWORD
     steps:
       - checkout
       - run:
           name: configure
-          command: ./waf configure
+          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
       - run:
           name: build
-          command: ./waf build
+          command: ./waf build -j4
       - run:
           name: test
-          command: ./waf --check
+          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
       - run:
           name: install
           command: ./waf install
-  gcc5_python34:
+  gcc6:
     docker:
-      - image: gcc:5
+      - image: docker.retrieva.jp/pficommon_ci:gcc6.2007
+        auth:
+          username: $DOCKER_REPO_USER
+          password: $DOCKER_REPO_PASSWORD
     steps:
       - checkout
       - run:
-          name: install python3.4
-          command: |
-            apt update -y
-            apt install -y python3
-      - run:
-          name: configure using python3.4
-          command: python3 ./waf configure
-      - run:
-          name: build using python3.4
-          command: python3 ./waf build
-      - run:
-          name: test using python3.4
-          command: python3 ./waf --check
-      - run:
-          name: install using python3.4
-          command: python3 ./waf install
-  gcc5_full:
-    docker:
-      - image: gcc:5
-    steps:
-      - checkout
-      - run:
-          name: install msgpack
-          command: |
-            wget https://github.com/msgpack/msgpack-c/releases/download/cpp-0.5.9/msgpack-0.5.9.tar.gz
-            tar zxvf msgpack-0.5.9.tar.gz && cd msgpack-0.5.9
-            ./configure && make && make install
-      - run:
-          name: install fcgi
-          command: |
-            wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz
-            tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz && cd fcgi-2.4.1-SNAP-0910052249
-            patch -u libfcgi/fcgio.cpp < ../patches/fcgi.patch
-            ./configure && make && make install
-      - run:
-          name: install mysql
-          command: |
-            apt update -y
-            apt install libmysqlclient-dev libmysqlclient18 mysql-common
-      - run:
-          name: install postgresql
-          command: |
-            apt update -y
-            apt install -y postgresql postgresql-server-dev-all
-      - run:
-          name: configure with all extensions except to imagemagick
-          command: |
-            CPPFLAGS="-I/usr/include/postgresql" ./waf configure --disable-fcgi
+          name: configure
+          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
       - run:
           name: build
-          command: ./waf build
+          command: ./waf build -j4
       - run:
           name: test
-          command: ./waf --check
+          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
+      - run:
+          name: install
+          command: ./waf install
+  gcc7:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:gcc7.2007
+        auth:
+          username: $DOCKER_REPO_USER
+          password: $DOCKER_REPO_PASSWORD
+    steps:
+      - checkout
+      - run:
+          name: configure
+          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
+      - run:
+          name: build
+          command: ./waf build -j4
+      - run:
+          name: test
+          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
+      - run:
+          name: install
+          command: ./waf install
+  gcc8:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:gcc8.2007
+        auth:
+          username: $DOCKER_REPO_USER
+          password: $DOCKER_REPO_PASSWORD
+    steps:
+      - checkout
+      - run:
+          name: configure
+          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
+      - run:
+          name: build
+          command: ./waf build -j4
+      - run:
+          name: test
+          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
+      - run:
+          name: install
+          command: ./waf install
+  gcc9:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:gcc9.2007
+        auth:
+          username: $DOCKER_REPO_USER
+          password: $DOCKER_REPO_PASSWORD
+    steps:
+      - checkout
+      - run:
+          name: configure
+          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
+      - run:
+          name: build
+          command: ./waf build -j4
+      - run:
+          name: test
+          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
       - run:
           name: install
           command: ./waf install
@@ -84,6 +104,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - gcc5_python27
-      - gcc5_python34
-      - gcc5_full
+      - gcc5
+      - gcc6
+      - gcc7
+      - gcc8
+      - gcc9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ jobs:
   gcc5:
     docker:
       - image: docker.retrieva.jp/pficommon_ci:gcc5.2007
-        auth:
+        auth: &auth
           username: $DOCKER_REPO_USER
           password: $DOCKER_REPO_PASSWORD
-    steps:
+    steps: &steps
       - checkout
       - run:
           name: configure
@@ -23,83 +23,23 @@ jobs:
   gcc6:
     docker:
       - image: docker.retrieva.jp/pficommon_ci:gcc6.2007
-        auth:
-          username: $DOCKER_REPO_USER
-          password: $DOCKER_REPO_PASSWORD
-    steps:
-      - checkout
-      - run:
-          name: configure
-          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
-      - run:
-          name: build
-          command: ./waf build -j4
-      - run:
-          name: test
-          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
-      - run:
-          name: install
-          command: ./waf install
+        auth: *auth
+    steps: *steps
   gcc7:
     docker:
       - image: docker.retrieva.jp/pficommon_ci:gcc7.2007
-        auth:
-          username: $DOCKER_REPO_USER
-          password: $DOCKER_REPO_PASSWORD
-    steps:
-      - checkout
-      - run:
-          name: configure
-          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
-      - run:
-          name: build
-          command: ./waf build -j4
-      - run:
-          name: test
-          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
-      - run:
-          name: install
-          command: ./waf install
+        auth: *auth
+    steps: *steps
   gcc8:
     docker:
       - image: docker.retrieva.jp/pficommon_ci:gcc8.2007
-        auth:
-          username: $DOCKER_REPO_USER
-          password: $DOCKER_REPO_PASSWORD
-    steps:
-      - checkout
-      - run:
-          name: configure
-          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
-      - run:
-          name: build
-          command: ./waf build -j4
-      - run:
-          name: test
-          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
-      - run:
-          name: install
-          command: ./waf install
+        auth: *auth
+    steps: *steps
   gcc9:
     docker:
       - image: docker.retrieva.jp/pficommon_ci:gcc9.2007
-        auth:
-          username: $DOCKER_REPO_USER
-          password: $DOCKER_REPO_PASSWORD
-    steps:
-      - checkout
-      - run:
-          name: configure
-          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
-      - run:
-          name: build
-          command: ./waf build -j4
-      - run:
-          name: test
-          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
-      - run:
-          name: install
-          command: ./waf install
+        auth: *auth
+    steps: *steps
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
       - checkout
       - run:
           name: configure
-          command: CPPFLAGS="-I/usr/include/postgresql" ./waf configure
+          command: ./waf configure
       - run:
           name: build
           command: ./waf build -j4
       - run:
           name: test
-          command: LD_LIBRARY_PATH="/usr/local/lib" ./waf --check -j4
+          command: ./waf --check -j4
       - run:
           name: install
           command: ./waf install

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,8 @@
+# Build Docker image for CI
+
+Run `build.py` as follows,
+
+```console
+$ cd docker
+$ python3 build.py
+```

--- a/docker/build.py
+++ b/docker/build.py
@@ -1,0 +1,35 @@
+import datetime
+import os
+import subprocess
+
+
+IMAGE_BASENAME = 'docker.retrieva.jp/pficommon_ci'
+base_images_and_tags = {
+    'gcc': [
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+    ]
+}
+
+
+def build_image(base_image, tag, build_date):
+    image_name = '{}:{}{}.{}'.format(
+        IMAGE_BASENAME, base_image, tag, build_date)
+    dockerfile_path = os.path.join(base_image, 'Dockerfile')
+    cmd = "docker build --no-cache --build-arg image_tag={} " \
+          "-t {} -f {} ..".format(tag, image_name, dockerfile_path)
+    subprocess.run(cmd, shell=True)
+
+
+def build_images(base_images_and_tags, build_date):
+    for base_image, tags in base_images_and_tags.items():
+        for tag in tags:
+            build_image(base_image, tag, build_date)
+
+
+if __name__ == '__main__':
+    today = datetime.date.today().strftime('%y%m')
+    build_images(base_images_and_tags, today)

--- a/docker/gcc/Dockerfile
+++ b/docker/gcc/Dockerfile
@@ -1,0 +1,32 @@
+ARG image_tag
+FROM gcc:${image_tag}
+
+ENV MSGPACK_VERSION 0.5.9
+
+RUN apt update \
+ && apt install -y \
+    python3 \
+    postgresql-server-dev-all \
+ && rm -rf /var/lib/apt/lists/*
+# Install msgpack
+RUN wget https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz \
+ && tar zxvf msgpack-${MSGPACK_VERSION}.tar.gz \
+ && cd msgpack-${MSGPACK_VERSION} \
+ && ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf msgpack-${MSGPACK_VERSION} \
+ && rm -f msgpack-${MSGPACK_VERSION}.tar.gz
+# Install fcgi
+ADD ./patches /patches
+RUN wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && cd fcgi-2.4.1-SNAP-0910052249 \
+ && patch -u libfcgi/fcgio.cpp < /patches/fcgi.patch \
+ && ./configure \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf fcgi-2.4.1-SNAP-0910052249 \
+ && rm -f fcgi-2.4.1-SNAP-0910052249.tar.gz

--- a/docker/gcc/Dockerfile
+++ b/docker/gcc/Dockerfile
@@ -1,6 +1,10 @@
 ARG image_tag
 FROM gcc:${image_tag}
 
+ENV C_INCLUDE_PATH=/usr/include/postgresql:$C_INCLUDE_PATH
+ENV CPLUS_INCLUDE_PATH=/usr/include/postgresql:$CPLUS_INCLUDE_PATH
+ENV LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH
 ENV MSGPACK_VERSION 0.5.9
 
 RUN apt update \

--- a/waf
+++ b/waf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: latin-1
 # Thomas Nagy, 2005-2018
 #


### PR DESCRIPTION
# What's this pull request for?

Enabled CI jobs to run in `gcc{5-9}`-based Docker images, where all dependencies (mysql, postgresql, fcgi, mprpc, etc.) are installed.
Added environment variables ( `DOCKER_REPO_USER` and `DOCKER_REPO_PASSWORD` ) in the project setting page of this repository so that CI can download images from docker.retrieva.jp .
In addition, `waf` is now executed only by `python3` because Python2 has ended and I don't wanna double the number of jobs.

# How to test

- [ ] check CI passes