### PR TITLE
Add centos7 and centos8 jobs to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,16 @@ jobs:
       - image: docker.retrieva.jp/pficommon_ci:gcc9.2007
         auth: *auth
     steps: *steps
+  centos7:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:centos7.2008
+        auth: *auth
+    steps: *steps
+  centos8:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:centos8.2008
+        auth: *auth
+    steps: *steps
 workflows:
   version: 2
   build_and_test:
@@ -55,3 +65,5 @@ workflows:
       - gcc7
       - gcc8
       - gcc9
+      - centos7
+      - centos8

--- a/docker/build.py
+++ b/docker/build.py
@@ -12,16 +12,29 @@ base_images_and_tags = {
         '7',
         '8',
         '9',
+    ],
+    'centos': [
+        '7',
+        '8',
     ]
 }
+
+
+def get_docker_build_command(image_name, base_image, tag):
+    dockerfile_path_per_tag = os.path.join(base_image, tag, 'Dockerfile')
+    if os.path.exists(dockerfile_path_per_tag):
+        return "docker build --no-cache -t {} -f {} ..".format(
+            image_name, dockerfile_path_per_tag)
+    else:
+        dockerfile_path = os.path.join(base_image, 'Dockerfile')
+        return "docker build --no-cache --build-arg image_tag={} " \
+               "-t {} -f {} ..".format(tag, image_name, dockerfile_path)
 
 
 def build_image(base_image, tag, build_date):
     image_name = '{}:{}{}.{}'.format(
         IMAGE_BASENAME, base_image, tag, build_date)
-    dockerfile_path = os.path.join(base_image, 'Dockerfile')
-    cmd = "docker build --no-cache --build-arg image_tag={} " \
-          "-t {} -f {} ..".format(tag, image_name, dockerfile_path)
+    cmd = get_docker_build_command(image_name, base_image, tag)
     subprocess.run(cmd, shell=True)
 
 

--- a/docker/centos/7/Dockerfile
+++ b/docker/centos/7/Dockerfile
@@ -1,0 +1,56 @@
+FROM centos:centos7
+
+ENV POSTGRESQL_VERSION 10
+ENV MSGPACK_VERSION 0.5.9
+
+ENV POSTGRESQL_PATH=/usr/pgsql-${POSTGRESQL_VERSION}
+ENV PATH=${POSTGRESQL_PATH}/bin:$PATH
+ENV C_INCLUDE_PATH=${POSTGRESQL_PATH}/include
+ENV CPLUS_INCLUDE_PATH=${POSTGRESQL_PATH}/include
+ENV LIBRARY_PATH=${POSTGRESQL_PATH}/lib:/usr/local/lib64:/usr/local/lib
+ENV LD_LIBRARY_PATH=${POSTGRESQL_PATH}/lib:/usr/local/lib64:/usr/local/lib
+
+RUN yum update -y \
+ && yum install -y \
+    @base \
+    @development \
+    python36 \
+ && yum clean all \
+ && rm -rf /var/cache/yum/*
+# Install mysql
+RUN yum localinstall -y \
+    http://dev.mysql.com/get/mysql57-community-release-el7-11.noarch.rpm \
+ && yum install -y \
+    mysql-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum/*
+# Install postgresql
+# https://www.postgresql.org/download/linux/redhat/
+RUN yum localinstall -y \
+    https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+ && yum install -y \
+    postgresql${POSTGRESQL_VERSION}-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum/*
+# Install msgpack
+RUN wget https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz \
+ && tar zxvf msgpack-${MSGPACK_VERSION}.tar.gz \
+ && pushd msgpack-${MSGPACK_VERSION} \
+ && ./configure \
+ && make \
+ && make install \
+ && popd \
+ && rm -rf msgpack-${MSGPACK_VERSION} \
+ && rm -f msgpack-${MSGPACK_VERSION}.tar.gz
+# Install fcgi
+ADD ./patches /patches
+RUN wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && pushd fcgi-2.4.1-SNAP-0910052249 \
+ && patch -u libfcgi/fcgio.cpp < /patches/fcgi.patch \
+ && ./configure \
+ && make \
+ && make install \
+ && popd \
+ && rm -rf fcgi-2.4.1-SNAP-0910052249 \
+ && rm -f fcgi-2.4.1-SNAP-0910052249.tar.gz

--- a/docker/centos/8/Dockerfile
+++ b/docker/centos/8/Dockerfile
@@ -1,0 +1,50 @@
+FROM centos:centos8
+
+ENV POSTGRESQL_VERSION 12
+ENV MSGPACK_VERSION 0.5.9
+
+ENV POSTGRESQL_PATH=/usr/pgsql-${POSTGRESQL_VERSION}
+ENV PATH=${POSTGRESQL_PATH}/bin:$PATH
+ENV C_INCLUDE_PATH=${POSTGRESQL_PATH}/include
+ENV CPLUS_INCLUDE_PATH=${POSTGRESQL_PATH}/include
+ENV LIBRARY_PATH=${POSTGRESQL_PATH}/lib:/usr/local/lib64:/usr/local/lib
+ENV LD_LIBRARY_PATH=${POSTGRESQL_PATH}/lib:/usr/local/lib64:/usr/local/lib
+
+RUN dnf update -y \
+ && dnf install -y \
+    @base \
+    @development \
+    python36 \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf/*
+# Install postgresql
+# https://www.postgresql.org/download/linux/redhat/
+RUN dnf install -y \
+    https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+ && dnf -qy module disable postgresql \
+ && dnf install -y \
+    postgresql${POSTGRESQL_VERSION}-devel \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf/*
+# Install msgpack
+RUN wget https://github.com/msgpack/msgpack-c/releases/download/cpp-${MSGPACK_VERSION}/msgpack-${MSGPACK_VERSION}.tar.gz \
+ && tar zxvf msgpack-${MSGPACK_VERSION}.tar.gz \
+ && pushd msgpack-${MSGPACK_VERSION} \
+ && ./configure \
+ && make \
+ && make install \
+ && popd \
+ && rm -rf msgpack-${MSGPACK_VERSION} \
+ && rm -f msgpack-${MSGPACK_VERSION}.tar.gz
+# Install fcgi
+ADD ./patches /patches
+RUN wget https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && tar zxvf fcgi-2.4.1-SNAP-0910052249.tar.gz \
+ && pushd fcgi-2.4.1-SNAP-0910052249 \
+ && patch -u libfcgi/fcgio.cpp < /patches/fcgi.patch \
+ && ./configure \
+ && make \
+ && make install \
+ && popd \
+ && rm -rf fcgi-2.4.1-SNAP-0910052249 \
+ && rm -f fcgi-2.4.1-SNAP-0910052249.tar.gz


### PR DESCRIPTION
# What I've done

Added `centos7` and `centos8` jobs to CI.

Note that different versions of mysql and postgresql are installed in each image.

||mysql|postgresql|
|:-:|:-:|:-:|
|`docker.retrieva.jp/pficommon_ci:centos7.2008`|5.7|10|
|`docker.retrieva.jp/pficommon_ci:centos8.2008`|-|12|

Only mysql8 can be installed in CentOS8 but building pficommon fails with that version (see #209 ), so mysql is not installed in `docker.retrieva.jp/pficommon_ci:centos8.2008` image.

Also, postgresql11 and 12 requires `llvm-toolset-7-clang` which is in `centos-release-scl` repository and I'm not sure it is good to activate that repo only for postgresql. That's why postgresql10 is installed in `docker.retrieva.jp/pficommon_ci:centos7.2008` image.

# How to test

- [x] All CI jobs passes.
- [x] Run `python3 build.py` and all images can be built.