### PR TITLE
Delete tr1::functional

### DIFF
--- a/src/lang/function.h
+++ b/src/lang/function.h
@@ -32,26 +32,13 @@
 #ifndef INCLUDE_GUARD_PFI_LANG_FUNCTION_H_
 #define INCLUDE_GUARD_PFI_LANG_FUNCTION_H_
 
-#include <tr1/functional>
+#include <functional>
 
 namespace pfi {
 namespace lang {
 
 template <class F>
-class function : public std::tr1::function<F> {
-  typedef std::tr1::function<F> base;
-
-public:
-  function() {}
-  template <class Fn>
-  function (const Fn& f) : base(f) {}
-
-  template <class Fn>
-  function& operator=(const Fn& f) {
-    base::operator=(f);
-    return *this;
-  }
-};
+using function = std::function<F>;
 
 } // lang
 } // pfi

--- a/src/lang/ref.h
+++ b/src/lang/ref.h
@@ -32,14 +32,14 @@
 #ifndef INCLUDE_GUARD_PFI_LANG_REF_H_
 #define INCLUDE_GUARD_PFI_LANG_REF_H_
 
-#include <tr1/functional>
+#include <functional>
 
 namespace pfi {
 namespace lang {
 
 template <class T>
-class reference_wrapper : public std::tr1::reference_wrapper<T> {
-  typedef std::tr1::reference_wrapper<T> base;
+class reference_wrapper : public std::reference_wrapper<T> {
+  typedef std::reference_wrapper<T> base;
 
 public:
   explicit reference_wrapper(T& x) : base(x) {}


### PR DESCRIPTION
# What I've done

Deleted dependency to `tr1::functional` . It still exists in `src/data/functional_hash.h`, but it's going to be deleted in #211 . 

We can declare `pfi::lang::reference_wrapper` by `using` if we replace `reference_wrapper::get_pointer` call with `reference_wrapper::get` . But I didn't do that in this pullreq because it breaks backward-compatibility.

# How to test

- [x] Check CI passes