### PR TITLE
Add a Dockerfile for building and serving documents

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,0 +1,9 @@
+FROM httpd:latest
+
+RUN apt update \
+ && apt install -y \
+    python3 \
+    python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+RUN pip3 install sphinx \
+ && rm -rf ~/.cache/pip/*

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,20 @@
+pficommon documents
+===
+
+Build a Docker image.
+
+```console
+$ docker build --no-cache -t pficommon_doc .
+```
+
+Run `make html` to build HTML of the documents.
+
+```console
+$ docker run --rm -v ${PWD}:${PWD} -w ${PWD} pficommon_doc /bin/bash -c 'make html'
+```
+
+Serve built HTML at http://localhost:8080 .
+
+```console
+$ docker run --rm -dit -v ${PWD}/build/html:/usr/local/apache2/htdocs -p 8080:80 pficommon_doc
+```


### PR DESCRIPTION
# What's this pull request for?

Add a Dockerfile so that developers can build and serve documents at their local environments.

# How to test

- [x] Docker image can be built.
- [x] Documents can be built.
- [x] Documents can be served.