### PR TITLE
Build with clang++-7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,13 @@ jobs:
       - image: docker.retrieva.jp/pficommon_ci:centos8.2008
         auth: *auth
     steps: *steps
+  clang7_on_gcc9_image:
+    docker:
+      - image: docker.retrieva.jp/pficommon_ci:gcc9.2007
+        auth: *auth
+    environment:
+      CXX: clang++-7
+    steps: *steps
 workflows:
   version: 2
   build_and_test:
@@ -67,3 +74,4 @@ workflows:
       - gcc9
       - centos7
       - centos8
+      - clang7_on_gcc9_image

--- a/src/data/serialization/reflect.h
+++ b/src/data/serialization/reflect.h
@@ -60,10 +60,6 @@ public:
   void print(std::ostream &os){
     os<<"bool";
   }
-
-private:
-  bool sign;
-  int size;
 };
 
 class int_type : public type_rep {

--- a/src/network/mprpc/caller.h
+++ b/src/network/mprpc/caller.h
@@ -48,7 +48,7 @@ namespace mprpc {
 
 typedef pfi::lang::function<pfi::lang::shared_ptr<rpc_stream>()> stream_getter;
 
-static void gen_exception(const rpc_response& res)
+static inline void gen_exception(const rpc_response& res)
 {
   switch(res.error_code()) {
   case METHOD_NOT_FOUND:

--- a/src/network/rpc/caller.h
+++ b/src/network/rpc/caller.h
@@ -45,7 +45,7 @@ typedef pfi::lang::function<pfi::lang::shared_ptr<socketstream>()> getter;
 typedef pfi::lang::function<void(pfi::lang::shared_ptr<socketstream>)> returner;
 typedef pfi::lang::function<int()> versioner;
 
-static void gen_exception(const std::string &str)
+static inline void gen_exception(const std::string &str)
 {
   std::istringstream iss(str);
   std::string code;

--- a/src/system/mmapper.cpp
+++ b/src/system/mmapper.cpp
@@ -59,7 +59,7 @@ int mmapper::open(const std::string& filename)
 
   const int prot = PROT_WRITE | PROT_READ;
   void* p;
-  NO_INTR(p, mmap(NULL, tmp.length, prot, MAP_SHARED, tmp.fd, 0));
+  p = mmap(NULL, tmp.length, prot, MAP_SHARED, tmp.fd, 0);
   if (p == MAP_FAILED)
     return -1;
   tmp.ptr = static_cast<char*>(p);

--- a/src/system/mmapper.h
+++ b/src/system/mmapper.h
@@ -53,13 +53,8 @@ public:
   ~mmapper() { close(); }
 
   mmapper& operator=(mmapper&& rhs) {
-    close();
-    ptr = std::move(rhs.ptr);
-    length = std::move(rhs.length);
-    fd = std::move(rhs.fd);
-    rhs.ptr = nullptr;
-    rhs.length = 0;
-    rhs.fd = -1;
+    mmapper tmp(std::move(rhs));
+    swap(tmp);
     return *this;
   }
 

--- a/src/system/mmapper.h
+++ b/src/system/mmapper.h
@@ -49,6 +49,8 @@ public:
   mmapper() : ptr(NULL), length(0), fd(-1) {}
   mmapper(mmapper&& rhs) : ptr(std::move(rhs.ptr)), length(std::move(rhs.length)), fd(std::move(rhs.fd)) {
     rhs.ptr = nullptr;
+    rhs.length = 0;
+    rhs.fd = -1;
   }
   ~mmapper() { close(); }
 

--- a/src/system/mmapper.h
+++ b/src/system/mmapper.h
@@ -48,9 +48,7 @@ public:
 
   mmapper() : ptr(NULL), length(0), fd(-1) {}
   mmapper(mmapper&& rhs) : ptr(std::move(rhs.ptr)), length(std::move(rhs.length)), fd(std::move(rhs.fd)) {
-    rhs.ptr = nullptr;
-    rhs.length = 0;
-    rhs.fd = -1;
+    mmapper().swap(rhs);
   }
   ~mmapper() { close(); }
 

--- a/src/system/mmapper.h
+++ b/src/system/mmapper.h
@@ -47,7 +47,18 @@ public:
   typedef const char* const_iterator;
 
   mmapper() : ptr(NULL), length(0), fd(-1) {}
+  mmapper(mmapper&& rhs) : ptr(std::move(rhs.ptr)), length(std::move(rhs.length)), fd(std::move(rhs.fd)) {
+    rhs.ptr = nullptr;
+  }
   ~mmapper() { close(); }
+
+  mmapper& operator=(mmapper&& rhs) {
+    delete ptr;
+    ptr = std::move(rhs.ptr);
+    length = std::move(rhs.length);
+    fd = std::move(rhs.fd);
+    return *this;
+  }
 
   char& operator[](size_t n) { return *(ptr + n); }
   const char& operator[](size_t n) const { return *(ptr + n); }

--- a/src/system/mmapper.h
+++ b/src/system/mmapper.h
@@ -55,10 +55,13 @@ public:
   ~mmapper() { close(); }
 
   mmapper& operator=(mmapper&& rhs) {
-    delete ptr;
+    close();
     ptr = std::move(rhs.ptr);
     length = std::move(rhs.length);
     fd = std::move(rhs.fd);
+    rhs.ptr = nullptr;
+    rhs.length = 0;
+    rhs.fd = -1;
     return *this;
   }
 

--- a/src/system/mmapper_test.cpp
+++ b/src/system/mmapper_test.cpp
@@ -41,6 +41,32 @@
 using namespace std;
 using namespace pfi::system::mmapper;
 
+TEST(mmapper_test, move_constructor)
+{
+  const std::string filename = "test.txt";
+  const std::string data = "0123456789";
+  const size_t size = data.size();
+  {
+    std::ofstream fs(filename, std::ios::out | std::ios::trunc);
+    fs << data;
+  }
+  {
+    mmapper rhs;
+    EXPECT_EQ(0, rhs.open(filename));
+    EXPECT_TRUE(rhs.is_open());
+    EXPECT_EQ(size, rhs.size());
+
+    mmapper lhs(std::move(rhs));
+    EXPECT_TRUE(lhs.is_open());
+    EXPECT_EQ(size, lhs.size());
+    EXPECT_FALSE(rhs.is_open());
+    EXPECT_EQ(0u, rhs.size());
+  }
+  {
+    unlink(filename.c_str());
+  }
+}
+
 TEST(mmapper_test, open_close_empty)
 {
   {

--- a/src/system/mmapper_test.cpp
+++ b/src/system/mmapper_test.cpp
@@ -67,6 +67,67 @@ TEST(mmapper_test, move_constructor)
   }
 }
 
+TEST(mmapper_test, move_assignment_operator)
+{
+  const std::string filename = "test.txt";
+  const std::string data = "0123456789";
+  const size_t size = data.size();
+  {
+    std::ofstream fs(filename, std::ios::out | std::ios::trunc);
+    fs << data;
+  }
+  {
+    mmapper rhs;
+    int r = rhs.open(filename);
+    EXPECT_EQ(r, 0);
+    EXPECT_TRUE(rhs.is_open());
+    EXPECT_EQ(size, rhs.size());
+
+    mmapper lhs = std::move(rhs);
+    EXPECT_TRUE(lhs.is_open());
+    EXPECT_EQ(size, lhs.size());
+    EXPECT_FALSE(rhs.is_open());
+    EXPECT_EQ(0u, rhs.size());
+  }
+  {
+    unlink(filename.c_str());
+  }
+}
+
+TEST(mmapper_test, move_assignment_operator_when_rhs_is_open)
+{
+  const std::string filename1 = "test1.txt", filename2 = "test2.txt";
+  const std::string data1 = "0123456789", data2 = "01234";
+  const size_t size1 = data1.size(), size2 = data2.size();
+  {
+    std::ofstream fs1(filename1, std::ios::out | std::ios::trunc);
+    fs1 << data1;
+    std::ofstream fs2(filename2, std::ios::out | std::ios::trunc);
+    fs2 << data2;
+  }
+  {
+    mmapper rhs;
+    EXPECT_EQ(0, rhs.open(filename2));
+    EXPECT_TRUE(rhs.is_open());
+    EXPECT_EQ(size2, rhs.size());
+
+    mmapper lhs;
+    EXPECT_EQ(0, lhs.open(filename1));
+    EXPECT_TRUE(lhs.is_open());
+    EXPECT_EQ(size1, lhs.size());
+
+    lhs = std::move(rhs);
+    EXPECT_TRUE(lhs.is_open());
+    EXPECT_EQ(size2, lhs.size());
+    EXPECT_FALSE(rhs.is_open());
+    EXPECT_EQ(0u, rhs.size());
+  }
+  {
+    unlink(filename1.c_str());
+    unlink(filename2.c_str());
+  }
+}
+
 TEST(mmapper_test, open_close_empty)
 {
   {

--- a/src/text/json/parser.cpp
+++ b/src/text/json/parser.cpp
@@ -116,7 +116,7 @@ public:
 };
 
 json_parser::json_parser(std::istream& is)
-  : is(is), it(is), end(), lineno(1), charno(1), cbuf(-1)
+  : it(is), end(), lineno(1), charno(1), cbuf(-1)
 {
   buf_len = 256;
   if ((buf = static_cast<char*>(malloc(buf_len))) == 0)

--- a/src/text/json/parser.h
+++ b/src/text/json/parser.h
@@ -152,7 +152,6 @@ private:
 
   void error(const std::string& msg);
 
-  std::istream& is;
   std::istreambuf_iterator<char> it, end;
 
   int lineno, charno;


### PR DESCRIPTION
This pullreq enables pficommon to be built with clang++-7 installed in `docker.retrieva.jp/pficommon_ci:gcc9.2007` image.
In addition, warnings when `./waf`is executed are suppressed in 38c062a and 8d27bf1 , but warnings when `./waf --check` is executed still remains because `./waf --check` by gcc also shows warnings.

There is `__gnu_cxx::stdio_filebuf` in sys/system/file.h , so build with clang++-7 and libc++ will fail.