### PR TITLE
Fix compilation error on clang

### DIFF
--- a/src/data/string/kmp.h
+++ b/src/data/string/kmp.h
@@ -33,6 +33,7 @@
 #define INCLUDE_GUARD_PFI_DATA_STRING_KMP_H_
 
 #include <iterator>
+#include <string>
 #include <vector>
 
 namespace pfi{

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <string>
 #include <algorithm>
+#include <iostream>
 #include <stdint.h>
 #include <stdexcept>
 

--- a/src/lang/function_test.cpp
+++ b/src/lang/function_test.cpp
@@ -93,7 +93,7 @@ TEST(function, comparison_with_null_pointer)
   EXPECT_FALSE(f != 0);
   EXPECT_FALSE(0 != f);
 
-  f = printf;
+  f = function<int (const char*)>(printf);
   EXPECT_FALSE(f == 0);
   EXPECT_FALSE(0 == f);
   EXPECT_TRUE(f != 0);

--- a/src/math/algebra_tester.h
+++ b/src/math/algebra_tester.h
@@ -43,7 +43,7 @@
       T3 c=G3();							\
       if(!EXPECT_EQ(a OP12 (b OP23 c),(a OP12 b) OP23 c)){		\
         std::cerr << "associativity broken for"				\
-                  << a << #OP12 << b << #OP23 << c << endl;		\
+                  << a << #OP12 << b << #OP23 << c << std::endl;        \
       }									\
     }									\
   }
@@ -54,14 +54,14 @@
 #define TEST_IDENTITY(CAPTION,N,T,G,ID,OP,EXPECT_EQ)		\
   TEST(CAPTION,identity){						\
     for(int i=0;i<N;++i){						\
-      T a=G();							\
+      T a=G();                                                          \
       if(!EXPECT_EQ(a OP ID,a)){					\
         std::cerr << ID << " is not right identity in"			\
-                  << a << #OP << ID << endl;				\
+                  << a << #OP << ID << std::endl;                       \
       }									\
       if(!EXPECT_EQ(ID OP a,a)){					\
         std::cerr << ID << " is not left identity in"			\
-                  << ID << #OP << a << endl;				\
+                  << ID << #OP << a << std::endl;                       \
       }									\
     }									\
   }
@@ -72,11 +72,11 @@
       TYPE a=GEN();							\
       if(!EXPECT_EQ(a OPI a,ID)){					\
         std::cerr << #OPI << " is not inverse operator in"		\
-                  << a << #OPI << a << endl;				\
+                  << a << #OPI << a << std::endl;                       \
       }									\
       if(!EXPECT_EQ(a OP (ID OPI a),ID)){				\
         std::cerr << #OPI << " is not inverse operator because "	\
-                  << ID << #OPI << a << " is not " << a << endl;	\
+                  << ID << #OPI << a << " is not " << a << std::endl;	\
       }									\
     }									\
   }
@@ -90,7 +90,7 @@
       T2 b=G2();							\
       if(!EXPECT_EQ(a OP b,b OP a)){					\
         std::cerr << "commutativity broken for"				\
-                  << a << #OP << b << endl;				\
+                  << a << #OP << b << std::endl;                        \
       }									\
     }									\
   }
@@ -108,21 +108,21 @@
       T2 c=G2();							\
       T3 lhs=a MUL c ADD b MUL c,rhs=(a ADD b) MUL c;			\
       if(!EXPECT_EQ(lhs,rhs)){						\
-        std::cerr << "distributivity broken for " << endl;		\
-        std::cerr << "a=" << a << endl;					\
-        std::cerr << "b=" << b << endl;					\
-        std::cerr << "c=" << c << endl;					\
+        std::cerr << "distributivity broken for " << std::endl;		\
+        std::cerr << "a=" << a << std::endl;                            \
+        std::cerr << "b=" << b << std::endl;                            \
+        std::cerr << "c=" << c << std::endl;                            \
         std::cerr << "a" #MUL "c" #ADD "b" #MUL "c=" << lhs << " ; "	\
-                  << "(a" #ADD "b)" #MUL "c=" << rhs << endl;		\
+                  << "(a" #ADD "b)" #MUL "c=" << rhs << std::endl;      \
       }									\
       T3 lhs2=c MUL a ADD c MUL b,rhs2=c MUL (a ADD b);			\
-      if(!EXPECT_EQ(lhs2,rhs2)){						\
-        std::cerr << "distributivity broken for " << endl;		\
-        std::cerr << "a=" << a << endl;					\
-        std::cerr << "b=" << b << endl;					\
-        std::cerr << "c=" << c << endl;					\
+      if(!EXPECT_EQ(lhs2,rhs2)){                                        \
+        std::cerr << "distributivity broken for " << std::endl;		\
+        std::cerr << "a=" << a << std::endl;                            \
+        std::cerr << "b=" << b << std::endl;                            \
+        std::cerr << "c=" << c << std::endl;                            \
         std::cerr << "c" #MUL "a" #ADD "c" #MUL "b=" << lhs << " ; "	\
-                  << "c" #MUL "(a" #ADD "b)=" << rhs << endl;		\
+                  << "c" #MUL "(a" #ADD "b)=" << rhs << std::endl;      \
       }									\
     }									\
   }

--- a/src/math/ratio_test.cpp
+++ b/src/math/ratio_test.cpp
@@ -40,7 +40,6 @@
 #include "./random.h"
 #include "algebra_tester.h"
 
-using namespace std;
 using namespace pfi::lang;
 using namespace pfi::math::random;
 using namespace pfi::math::ratio;
@@ -57,13 +56,13 @@ ratio<int> gen_ratio(){
 
 bool expect_eq(const ratio<int> &a, const ratio<int> &b){
   bool ret=a==b; 
-  ostringstream oss; oss << a << "!=" << b << endl;
+  std::ostringstream oss; oss << a << "!=" << b << std::endl;
   EXPECT_TRUE(ret) << oss.str();
   return ret;
 }
 
 TEST(ratio,printing){
-  std::cerr << ratio<int>(1341,398) << endl;
+  std::cerr << ratio<int>(1341,398) << std::endl;
 }
 
 ratio<int> zero(0);

--- a/src/network/http/base.cpp
+++ b/src/network/http/base.cpp
@@ -370,9 +370,8 @@ template <class C, class T = char_traits<C> >
 class basic_httpbody_chunked_stream : public basic_iostream<C, T> {
 public:
   explicit basic_httpbody_chunked_stream(const pfi::lang::shared_ptr<stream_socket>& sock)
-    : basic_iostream<C,T>(), buf(sock)
+    : basic_iostream<C,T>(&buf), buf(sock)
   {
-    this->init(&buf);
   }
 
 private:
@@ -383,10 +382,9 @@ template <class C, class T = char_traits<C> >
 class basic_httpbody_stream : public basic_iostream<C, T> {
 public:
   basic_httpbody_stream(const pfi::lang::shared_ptr<stream_socket>& sock, int64_t len)
-    : basic_iostream<C,T>(),
+    : basic_iostream<C,T>(&buf),
       buf(sock, len)
   {
-    this->init(&buf);
   }
 private:
   basic_httpbody_streambuf<C, T> buf;

--- a/src/network/http/stream.h
+++ b/src/network/http/stream.h
@@ -97,9 +97,8 @@ template <class C, class T = std::char_traits<C> >
 class basic_httpstream : public std::basic_istream<C, T> {
 public:
   explicit basic_httpstream(const std::string& url)
-    : buf(url)
+      : std::basic_istream<C, T>(&buf), buf(url)
   {
-    this->init(&buf);
   }
 
   header& head() {

--- a/src/network/iostream.h
+++ b/src/network/iostream.h
@@ -139,20 +139,17 @@ template <class C, class T = std::char_traits<C> >
 class basic_socketstream : public std::basic_iostream<C,T>{
 public:
   basic_socketstream()
-    : std::basic_iostream<C,T>(){
-    this->init(&sockbuf);
+    : std::basic_iostream<C,T>(&sockbuf){
   }
 
   basic_socketstream(const std::string &host, uint16_t port)
-    : std::basic_iostream<C,T>(){
-    this->init(&sockbuf);
+    : std::basic_iostream<C,T>(&sockbuf){
     connect(host, port);
   }
 
   template <class PSOCK>
   basic_socketstream(PSOCK sock)
-    : std::basic_iostream<C,T>(){
-    this->init(&sockbuf);
+    : std::basic_iostream<C,T>(&sockbuf){
     setsock(sock);
   }
 

--- a/tools/genrpc/main.cpp
+++ b/tools/genrpc/main.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <fstream>
 #include <sstream>
 #include <stdexcept>
 #include <cctype>


### PR DESCRIPTION
This pull request fix compilation errors on clang 10.0.0 / macOS High Sierra.

* fix to include your own header
* fix to call std::basic_iostream's constructor correctly
* resolve conflictions between std library and pficommon in test codes
