### PR TITLE
Use std::enable_if as pfi::lang::enable_if

### DIFF
--- a/doc/source/lang.rst
+++ b/doc/source/lang.rst
@@ -9,6 +9,7 @@ C++を書きやすくする類のライブラリ。 ほぼBoostの再実装。
 
   lang/bind
   lang/cast
+  lang/enable_if
   lang/function
   lang/mem_fn
   lang/noncopyable

--- a/doc/source/lang/enable_if.rst
+++ b/doc/source/lang/enable_if.rst
@@ -1,0 +1,49 @@
+====================
+pfi::lang::enable_if
+====================
+
+概要
+====
+
+.. code-block:: c++
+
+  template <bool B_, class T = void>
+  using enable_if = std::enable_if<B_, T>;
+
+  template <bool B_, class T = void>
+  struct disable_if : enable_if<!B_, T> {};
+
+コンパイル時、 :code:`B_` がtrueであれば :code:`type` メンバを持つ :code:`enable_if` 、 falseであれば :code:`type` メンバを持つ :code:`disable_if` を提供する。
+
+
+使い方
+======
+
+.. code-block:: c++
+
+  template <class T>
+  auto f(T) -> typename pfi::lang::enable_if<std::is_integral<T>::value>::type {}
+
+関数の引数や戻り値、テンプレート引数のデフォルト値などで :code:`enable_if` や :code:`diable_if` の :code:`type` メンバを使用すると、 SFINAEにより :code:`type` メンバが存在しない場合はその関数はオーバーロード解決の対象から除外される。
+
+
+サンプルコード
+=============
+
+.. code-block:: c++
+
+  template <class T>
+  auto f(T) -> typename pfi::lang::enable_if<std::is_integral<T>::value>::type
+  {
+    std::cout << "Tは整数型" << std::endl;
+  }
+
+  template <class T>
+  auto f(T) -> typename pfi::lang::disable_if<std::is_integral<T>::value>::type
+  {
+    std::cout << "Tは整数型以外" << std::endl;
+  }
+
+  f(3);  // Tは整数型
+  f("hello");  // Tは整数型以外
+

--- a/src/lang/enable_if.h
+++ b/src/lang/enable_if.h
@@ -32,26 +32,16 @@
 #ifndef INCLUDE_GUARD_PFI_LANG_ENABLE_IF_H_
 #define INCLUDE_GUARD_PFI_LANG_ENABLE_IF_H_
 
+#include <type_traits>
+
 namespace pfi {
 namespace lang {
 
-template <bool, class T = void>
-struct enable_if_c {};
+template <bool B_, class T = void>
+using enable_if = std::enable_if<B_, T>;
 
-template <class T>
-struct enable_if_c<true, T> {
-  typedef T type;
-};
-
-template <bool B, class T = void>
-struct disable_if_c : enable_if_c<!B, T> {};
-
-
-template <class B_, class T = void>
-struct enable_if : enable_if_c<B_::value, T> {};
-
-template <class B_, class T = void>
-struct disable_if : disable_if_c<B_::value, T> {};
+template <bool B_, class T = void>
+struct disable_if : enable_if<!B_, T> {};
 
 } // namespace lang
 } // namespace pfi

--- a/src/lang/enable_if_test.cpp
+++ b/src/lang/enable_if_test.cpp
@@ -31,39 +31,16 @@
 
 #include "enable_if.h"
 
-template <bool Value>
-struct bool_ {
-  typedef bool_ type;
-  static const bool value = Value;
-};
-
-typedef bool_<false> false_;
-typedef bool_<true> true_;
-
-
-template <class _>
-struct is_floating_point : false_ {};
-
-template <>
-struct is_floating_point<float> : true_ {};
-
-template <>
-struct is_floating_point<double> : true_ {};
-
-template <>
-struct is_floating_point<long double> : true_ {};
-
-
 #include <string>
 
 template <class T>
-std::string is_floating_point_(const T&, typename pfi::lang::enable_if<is_floating_point<T> >::type* = 0)
+std::string is_floating_point_(const T&, typename pfi::lang::enable_if<std::is_floating_point<T>::value>::type* = 0)
 {
   return "floating point";
 }
 
 template <class T>
-std::string is_floating_point_(const T&, typename pfi::lang::disable_if<is_floating_point<T> >::type* = 0)
+std::string is_floating_point_(const T&, typename pfi::lang::disable_if<std::is_floating_point<T>::value>::type* = 0)
 {
   return "not floating point";
 }


### PR DESCRIPTION
This change contains backward incompatibility, so I've opened this as draft pullreq to get feedback.

# Changes

This pullreq uses `std::enable_if` as `pfi::lang_enable_if`
because C++11 has `std::enable_if` and pficommon does not need to maintain its own implementation.

# Backward Incompatibility

The template parameter of `pfi::lang::enable_if` has changed.