### PR TITLE
Apply two-phase termination to rpc_server

### DIFF
--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -81,6 +81,7 @@ void rpc_server::add(const string &name, const pfi::lang::shared_ptr<invoker_bas
 bool rpc_server::serv(uint16_t port, int nthreads)
 {
   if (!start(port, nthreads)) {
+    stop();
     return false;
   }
   wait_until_stopped();

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -47,16 +47,29 @@ namespace rpc{
 
 static const char *PING_MSG = "<<<PING>>>";
 static const char *PONG_MSG = "<<<PONG>>>";
+static const char *EXIT_MSG = "<<<EXIT>>>";
 
-// server
-rpc_server::rpc_server(int version, double timeout_sec)
-  : version(version), timeout_sec(timeout_sec)
-{
+// TODO: catch exception which std::mutex::mutex() throws
+rpc_server::rpc_server(int version, double timeout_sec) : version(version),
+                                                          timeout_sec(timeout_sec),
+                                                          threads_mutex(),
+                                                          num_running_threads(0),
+                                                          threads(),
+                                                          state_mutex(),
+                                                          state(server_state::STOPPED),
+                                                          stop_condition() {
   port_num = 0;
 }
 
 rpc_server::~rpc_server()
 {
+  for (size_t i = 0; i < threads.size(); ++i) {
+    threads[i]->join();
+  }
+  if (socket) {
+    socket->close();
+    socket.reset();
+  }
 }
 
 void rpc_server::add(const string &name, const pfi::lang::shared_ptr<invoker_base>& invoker)
@@ -66,20 +79,77 @@ void rpc_server::add(const string &name, const pfi::lang::shared_ptr<invoker_bas
 
 bool rpc_server::serv(uint16_t port, int nthreads)
 {
-  pfi::lang::shared_ptr<server_socket> ssock(new server_socket());
-  if (!ssock->create(port))
+  if (!start(port, nthreads)) {
+    return false;
+  }
+  wait_until_stopped();
+  return true;
+}
+
+bool rpc_server::start(uint16_t port, int nthreads)
+{
+  socket = pfi::lang::shared_ptr<server_socket>(new server_socket());
+  if (!socket->create(port))
     return false;
 
-  port_num = ssock->port();
+  port_num = socket->port();
 
-  vector<pfi::lang::shared_ptr<thread> > ths(nthreads);
-  for (int i=0; i<nthreads; i++){
-      ths[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&rpc_server::process, this, ssock)));
-    if (!ths[i]->start()) return false;
+  // NOTE: state should be set as `running` before starting threads
+  //       because each thread runs while the state is `running`.
+  set_state(server_state::RUNNING);
+  {
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    threads = vector<pfi::lang::shared_ptr<thread>>(nthreads);
+    for (int i=0; i<nthreads; i++){
+      threads[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&rpc_server::process, this, socket)));
+      if (!threads[i]->start()) return false;
+      ++num_running_threads;
+    }
   }
-  for (int i=0; i<nthreads; i++)
-    ths[i]->join();
   return true;
+}
+
+void rpc_server::stop()
+{
+  if (!is_running()) {
+    return;
+  }
+  set_state(server_state::STOPPING);
+  if (socket) {
+    socket->close();
+    for (size_t i = 0; i < threads.size(); ++i) {
+      rpc_client client("localhost", port());
+      auto request_termination = client.call<bool()>(EXIT_MSG);
+      request_termination();
+    }
+  }
+}
+
+void rpc_server::wait_until_stopped()
+{
+  if (is_stopped()) {
+    return;
+  }
+  std::unique_lock<std::mutex> lock(state_mutex);
+  stop_condition.wait(lock, [this]() { return state == server_state::STOPPED; });
+}
+
+bool rpc_server::is_running() const
+{
+  std::lock_guard<std::mutex> lock(state_mutex);
+  return state == server_state::RUNNING;
+}
+
+bool rpc_server::is_stopping() const
+{
+  std::lock_guard<std::mutex> lock(state_mutex);
+  return state == server_state::STOPPING;
+}
+
+bool rpc_server::is_stopped() const
+{
+  std::lock_guard<std::mutex> lock(state_mutex);
+  return state == server_state::STOPPED;
 }
 
 uint16_t rpc_server::port() const
@@ -89,7 +159,7 @@ uint16_t rpc_server::port() const
 
 void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
 {
-  for (;;){
+  while (is_running()){
     pfi::lang::shared_ptr<stream_socket> sock(ssock->accept());
     if (!sock) continue;
     sock->set_nodelay(true);
@@ -114,6 +184,14 @@ void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
         oa<<t;
         oa.flush();
         continue;
+      } else if (name==EXIT_MSG) {
+        string result_code("OK");
+        oa<<result_code;
+        oa.flush();
+        string ret("1");
+        oa<<ret;
+        oa.flush();
+        break;
       }
 
       if (funcs.count(name)==0){
@@ -138,6 +216,25 @@ void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
       }
     }
   }
+  {
+    std::lock_guard<std::mutex> lock(threads_mutex);
+    --num_running_threads;
+  }
+  if (!exist_running_threads()) {
+    set_state(server_state::STOPPED);
+    stop_condition.notify_one();
+  }
+}
+
+bool rpc_server::exist_running_threads() const
+{
+  std::lock_guard<std::mutex> lock(threads_mutex);
+  return num_running_threads > 0;
+}
+
+void rpc_server::set_state(const server_state& next_state) {
+  std::lock_guard<std::mutex> lock(state_mutex);
+  state = next_state;
 }
 
 rpc_client::rpc_client(const string &host, uint16_t port, int version)

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -120,7 +120,12 @@ void rpc_server::stop()
     for (size_t i = 0; i < threads.size(); ++i) {
       rpc_client client("localhost", port());
       auto request_termination = client.call<bool()>(EXIT_MSG);
-      request_termination();
+      // NOTE: Now that socket is closed,
+      //       when there is no server thread which waits at `server::socket::accept()`
+      //       this RPC call will throw `cannot_get_connection` exception.
+      try {
+        request_termination();
+      } catch (const cannot_get_connection&) {}
     }
   }
 }

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -181,7 +181,7 @@ void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
       string name;
       ia>>name;
 
-      // NOTE: When a connection ends (e.g. by destuctor of the connected client being called),
+      // NOTE: When a connection ends (e.g. by destructor of the connected client being called),
       //       the server thread gets empty string from `binary_archive`
       //       and exits this for loop here.
       if (!ss)

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -110,10 +110,11 @@ bool rpc_server::start(uint16_t port, int nthreads)
 
 void rpc_server::stop()
 {
-  if (!is_running()) {
+  std::lock_guard<std::mutex> lock(state_mutex);
+  if (!is_running_unsafe()) {
     return;
   }
-  set_state(server_state::STOPPING);
+  state = server_state::STOPPING;
   if (socket) {
     socket->close();
     for (size_t i = 0; i < threads.size(); ++i) {

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -176,6 +176,9 @@ void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
       string name;
       ia>>name;
 
+      // NOTE: When a connection ends (e.g. by destuctor of the connected client being called),
+      //       the server thread gets empty string from `binary_archive`
+      //       and exits this for loop here.
       if (!ss)
         break;
 

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -63,7 +63,9 @@ rpc_server::rpc_server(int version, double timeout_sec) : version(version),
 rpc_server::~rpc_server()
 {
   for (size_t i = 0; i < threads.size(); ++i) {
-    threads[i]->join();
+    if (threads[i]) {
+      threads[i]->join();
+    }
   }
   if (socket) {
     socket->close();

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -127,10 +127,10 @@ void rpc_server::stop()
 
 void rpc_server::wait_until_stopped()
 {
-  if (is_stopped()) {
+  std::unique_lock<std::mutex> lock(state_mutex);
+  if (is_stopped_unsafe()) {
     return;
   }
-  std::unique_lock<std::mutex> lock(state_mutex);
   stop_condition.wait(lock, [this]() { return state == server_state::STOPPED; });
 }
 

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -137,19 +137,19 @@ void rpc_server::wait_until_stopped()
 bool rpc_server::is_running() const
 {
   std::lock_guard<std::mutex> lock(state_mutex);
-  return state == server_state::RUNNING;
+  return is_running_unsafe();
 }
 
 bool rpc_server::is_stopping() const
 {
   std::lock_guard<std::mutex> lock(state_mutex);
-  return state == server_state::STOPPING;
+  return is_stopping_unsafe();
 }
 
 bool rpc_server::is_stopped() const
 {
   std::lock_guard<std::mutex> lock(state_mutex);
-  return state == server_state::STOPPED;
+  return is_stopped_unsafe();
 }
 
 uint16_t rpc_server::port() const
@@ -224,6 +224,21 @@ void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
     set_state(server_state::STOPPED);
     stop_condition.notify_one();
   }
+}
+
+bool rpc_server::is_running_unsafe() const
+{
+  return state == server_state::RUNNING;
+}
+
+bool rpc_server::is_stopping_unsafe() const
+{
+  return state == server_state::STOPPING;
+}
+
+bool rpc_server::is_stopped_unsafe() const
+{
+  return state == server_state::STOPPED;
 }
 
 bool rpc_server::exist_running_threads() const

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -93,11 +93,11 @@ bool rpc_server::start(uint16_t port, int nthreads)
 
   port_num = socket->port();
 
-  // NOTE: state should be set as `running` before starting threads
-  //       because each thread runs while the state is `running`.
-  set_state(server_state::RUNNING);
   {
     std::lock_guard<std::mutex> lock(state_mutex);
+    // NOTE: state should be set as `running` before starting threads
+    //       because each thread runs while the state is `running`.
+    state = server_state::RUNNING;
     threads = vector<pfi::lang::shared_ptr<thread>>(nthreads);
     for (int i=0; i<nthreads; i++){
       threads[i]=pfi::lang::shared_ptr<thread>(new thread(bind(&rpc_server::process, this, socket)));
@@ -244,11 +244,6 @@ void rpc_server::notify_if_this_is_the_last_running_threads()
     state = server_state::STOPPED;
   }
   stop_condition.notify_one();
-}
-
-void rpc_server::set_state(const server_state& next_state) {
-  std::lock_guard<std::mutex> lock(state_mutex);
-  state = next_state;
 }
 
 rpc_client::rpc_client(const string &host, uint16_t port, int version)

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -96,8 +96,6 @@ private:
 
   void notify_if_this_is_the_last_running_threads();
 
-  void set_state(const server_state& next_state);
-
   std::map<std::string, pfi::lang::shared_ptr<invoker_base> > funcs;
 
   pfi::lang::shared_ptr<pfi::network::server_socket> socket;

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -90,6 +90,10 @@ private:
 
   void process(const pfi::lang::shared_ptr<server_socket>& sock);
 
+  bool is_running_unsafe() const;
+  bool is_stopping_unsafe() const;
+  bool is_stopped_unsafe() const;
+
   bool exist_running_threads() const;
 
   void set_state(const server_state& next_state);

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -106,13 +106,12 @@ private:
   const int version;
   const double timeout_sec;
 
-  mutable std::mutex threads_mutex;
+  // state_mutex also guards variables for threads
+  mutable std::mutex state_mutex;
+  std::condition_variable_any stop_condition;
+  server_state state;
   int num_running_threads;
   std::vector<pfi::lang::shared_ptr<pfi::concurrent::thread>> threads;
-
-  mutable std::mutex state_mutex;
-  server_state state;
-  std::condition_variable_any stop_condition;
 };
 
 class rpc_client{

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -58,9 +58,9 @@ namespace network{
 namespace rpc{
 
 enum class server_state {
+  STOPPED,
   RUNNING,
   STOPPING,
-  STOPPED
 };
 
 class rpc_server{

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -94,7 +94,7 @@ private:
   bool is_stopping_unsafe() const;
   bool is_stopped_unsafe() const;
 
-  bool exist_running_threads() const;
+  void notify_if_this_is_the_last_running_threads();
 
   void set_state(const server_state& next_state);
 

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -32,9 +32,12 @@
 #ifndef INCLUDE_GUARD_PFI_NETWORK_RPC_BASE_H_
 #define INCLUDE_GUARD_PFI_NETWORK_RPC_BASE_H_
 
+#include <condition_variable>
 #include <map>
+#include <mutex>
 #include <string>
 #include <stdexcept>
+#include <vector>
 
 #include "../../lang/bind.h"
 #include "../../lang/function.h"
@@ -54,6 +57,12 @@ namespace pfi{
 namespace network{
 namespace rpc{
 
+enum class server_state {
+  RUNNING,
+  STOPPING,
+  STOPPED
+};
+
 class rpc_server{
 public:
   rpc_server(int version=0, double timeout_sec=0.0);
@@ -65,6 +74,13 @@ public:
   }
 
   bool serv(uint16_t port, int nthreads);
+  bool start(uint16_t port, int nthreads);
+  void stop();
+  void wait_until_stopped();
+
+  bool is_running() const;
+  bool is_stopping() const;
+  bool is_stopped() const;
 
   uint16_t port() const;
 
@@ -74,12 +90,25 @@ private:
 
   void process(const pfi::lang::shared_ptr<server_socket>& sock);
 
+  bool exist_running_threads() const;
+
+  void set_state(const server_state& next_state);
+
   std::map<std::string, pfi::lang::shared_ptr<invoker_base> > funcs;
 
+  pfi::lang::shared_ptr<pfi::network::server_socket> socket;
   uint16_t port_num;
 
   const int version;
   const double timeout_sec;
+
+  mutable std::mutex threads_mutex;
+  int num_running_threads;
+  std::vector<pfi::lang::shared_ptr<pfi::concurrent::thread>> threads;
+
+  mutable std::mutex state_mutex;
+  server_state state;
+  std::condition_variable_any stop_condition;
 };
 
 class rpc_client{

--- a/src/network/rpc_test.cpp
+++ b/src/network/rpc_test.cpp
@@ -40,20 +40,16 @@
 #include "../lang/ref.h"
 #include "../concurrent/thread.h"
 
-using namespace std;
-using namespace pfi::lang;
-using namespace pfi::concurrent;
-
-RPC_PROC(test_str, string(string));
-static string test_str(const string& v){ return v; }
-RPC_PROC(test_pair, pair<int,string>(pair<int,string>));
-static pair<int,string> test_pair(const pair<int,string>& v){ return v; }
-RPC_PROC(test_vec, vector<int>(vector<int>));
-static vector<int> test_vec(const vector<int>& v){ return v; }
-RPC_PROC(test_map, map<int,int>(map<int,int>));
-static map<int, int> test_map(const map<int, int>& v){ return v; }
-RPC_PROC(test_set, set<int>(set<int> v));
-static set<int> test_set(const set<int>& v){ return v; }
+RPC_PROC(test_str, std::string(std::string));
+static std::string test_str(const std::string& v){ return v; }
+RPC_PROC(test_pair, std::pair<int,std::string>(std::pair<int,std::string>));
+static std::pair<int,std::string> test_pair(const std::pair<int,std::string>& v){ return v; }
+RPC_PROC(test_vec, std::vector<int>(std::vector<int>));
+static std::vector<int> test_vec(const std::vector<int>& v){ return v; }
+RPC_PROC(test_map, std::map<int,int>(std::map<int,int>));
+static std::map<int, int> test_map(const std::map<int, int>& v){ return v; }
+RPC_PROC(test_set, std::set<int>(std::set<int> v));
+static std::set<int> test_set(const std::set<int>& v){ return v; }
 
 RPC_GEN(1, testrpc, test_str, test_pair, test_vec, test_map, test_set);
 
@@ -71,7 +67,7 @@ TEST(rpc, rpc_test)
 {
   testrpc_server ser;
   EXPECT_TRUE(ser.is_stopped());
-  thread t(pfi::lang::bind(&server_thread, pfi::lang::ref(ser)));
+  pfi::concurrent::thread t(pfi::lang::bind(&server_thread, pfi::lang::ref(ser)));
   t.start();
 
   sleep(1);
@@ -83,40 +79,40 @@ TEST(rpc, rpc_test)
     int times = 100;
     for (int t=0;t<times;t++) {
       {
-        string v;
+        std::string v;
         for (int i=0;i<10;i++)
           v+='0'+(rand()%10);
-        string r;
+        std::string r;
         EXPECT_NO_THROW({ r = cln.call_test_str(v); });
         EXPECT_EQ(r.size(), 10U);
         for (int i=0;i<10;i++)
           EXPECT_EQ(r[i], v[i]);
       }
       {
-        string vs;
+        std::string vs;
         for (int i=0;i<10;i++)
           vs+='0'+(rand()%10);
-        pair<int, string> v = make_pair(rand(), vs);
-        pair<int, string> r;
+        std::pair<int, std::string> v = make_pair(rand(), vs);
+        std::pair<int, std::string> r;
         EXPECT_NO_THROW({ r = cln.call_test_pair(v); });
         EXPECT_EQ(r.first, v.first);
         EXPECT_EQ(r.second, v.second);
       }
       {
-        vector<int> v;
+        std::vector<int> v;
         for (int i=0;i<10;i++)
           v.push_back(rand());
-        vector<int> r;
+        std::vector<int> r;
         EXPECT_NO_THROW({ r = cln.call_test_vec(v); });
         EXPECT_EQ(r.size(), 10U);
         for (int i=0;i<10;i++)
           EXPECT_EQ(r[i], v[i]);
       }
       {
-        map<int, int> v;
+        std::map<int, int> v;
         for (int i=0;i<10;i++)
           v[i]=rand();
-        map<int, int> r;
+        std::map<int, int> r;
         EXPECT_NO_THROW({ r = cln.call_test_map(v); });
         EXPECT_EQ(r.size(), 10U);
         for (int i=0;i<10;i++){
@@ -124,14 +120,14 @@ TEST(rpc, rpc_test)
         }
       }
       {
-        set<int> v;
+        std::set<int> v;
         for (int i=0;i<10;i++)
           v.insert(i*100);
-        set<int> r;
+        std::set<int> r;
         EXPECT_NO_THROW({ r = cln.call_test_set(v); });
         EXPECT_EQ(r.size(), 10U);
         int cnt = 0;
-        for (set<int>::iterator it=v.begin();it!=v.end();++it){
+        for (std::set<int>::iterator it=v.begin();it!=v.end();++it){
           EXPECT_EQ(*it, cnt++ * 100);
         }
       }
@@ -146,7 +142,7 @@ TEST(rpc, rpc_test)
 // test for struct and empty vector
 struct tstruct {
   int i;
-  vector<unsigned char> v;
+  std::vector<unsigned char> v;
   
 private:
   friend class pfi::data::serialization::access;
@@ -171,7 +167,7 @@ TEST(rpc, test_struct)
 
   test_struct_rpc_server ser;
   EXPECT_TRUE(ser.is_stopped());
-  thread t(pfi::lang::bind(&struct_server_thread, pfi::lang::ref(ser), port, num_threads));
+  pfi::concurrent::thread t(pfi::lang::bind(&struct_server_thread, pfi::lang::ref(ser), port, num_threads));
   t.start();
 
   sleep(1);
@@ -212,8 +208,8 @@ TEST(rpc, test_server_port_0)
   sas.arg_port = 0;
   EXPECT_TRUE(sas.sv.is_stopped());
 
-  pfi::lang::function<void(void)> f = bind(server_thread_for_port_0, &sas);
-  thread t(f);
+  pfi::lang::function<void(void)> f = pfi::lang::bind(server_thread_for_port_0, &sas);
+  pfi::concurrent::thread t(f);
   t.start();
   sleep(1);
   EXPECT_TRUE(sas.sv.is_running());
@@ -223,10 +219,10 @@ TEST(rpc, test_server_port_0)
 
   {
     testrpc_client cln("localhost", p0);
-    string v;
+    std::string v;
     for (int i=0;i<10;i++)
       v+='0'+(rand()%10);
-    string r;
+    std::string r;
     EXPECT_NO_THROW({ r = cln.call_test_str(v); });
     EXPECT_EQ(r.size(), 10U);
     for (int i=0;i<10;i++)
@@ -263,14 +259,14 @@ TEST(rpc, test_rpc_server_timeout)
   double test_timeout_sec = 1.0;
   test_struct_rpc_server ser(test_timeout_sec);
   EXPECT_TRUE(ser.is_stopped());
-  thread t(pfi::lang::bind(&server_thread_for_timeout, pfi::lang::ref(ser)));
+  pfi::concurrent::thread t(pfi::lang::bind(&server_thread_for_timeout, pfi::lang::ref(ser)));
   t.start();
 
   sleep(1);
   EXPECT_TRUE(ser.is_running());
 
   uint64_t time0 = get_monotonic_time_micro_sec();
-  thread dummy_client(&dummy_client_for_timeout);
+  pfi::concurrent::thread dummy_client(&dummy_client_for_timeout);
   dummy_client.start();
   dummy_client.detach();
 
@@ -312,12 +308,12 @@ TEST(rpc, test_server_termination_after_long_running_client_ends)
 
   test_struct_rpc_server server;
   EXPECT_TRUE(server.is_stopped());
-  thread server_thread(pfi::lang::bind(&struct_server_thread, pfi::lang::ref(server), port, num_threads));
+  pfi::concurrent::thread server_thread(pfi::lang::bind(&struct_server_thread, pfi::lang::ref(server), port, num_threads));
   server_thread.start();
   sleep(1);
   EXPECT_TRUE(server.is_running());
 
-  thread client_thread(pfi::lang::bind(&long_running_client_thread, port));
+  pfi::concurrent::thread client_thread(pfi::lang::bind(&long_running_client_thread, port));
   client_thread.start();
   client_thread.detach();
   sleep(1);


### PR DESCRIPTION
Applied two-phase termination to `pfi::network::rpc::rpc_server` by adding `start()` `stop()` `wait_until_stopped()` methods().

The approach is to create an internal client which sends an exit message to the server.

We can extract `server` interface which has methods for two-phase termination so that `pfi::network::mprpc::mprpc_server`can inherit from the interface, but I haven't done it yet.